### PR TITLE
Fixes for auto-pull

### DIFF
--- a/lib/auto-pull.js
+++ b/lib/auto-pull.js
@@ -14,21 +14,27 @@ import rx           from "rxjs";
 
 import * as rxx     from "@amrc-factoryplus/rx-util";
 
-const PullSpec = imm.Record({
+const duration_or_never = i => i == "never" ? -1 : duration(i);
+
+class PullSpec extends imm.Record({
     uuid:       null,
     branch:     null,
     url:        null,
     ref:        "main",
     interval:   null,
     ff:         null,
-});
-const duration_or_never = i => i == "never" ? -1 : duration(i);
-PullSpec.of = (uuid, branch, conf) => PullSpec({
-    ...conf,
-    uuid, branch,
-    interval:   duration_or_never(conf.interval ?? "1h"),
-    ff:         conf.merge,
-});
+}) {
+    static of (uuid, branch, conf) {
+        return new PullSpec({
+            ...conf,
+            uuid, branch,
+            interval:   duration_or_never(conf.interval ?? "1h"),
+            ff:         conf.merge,
+        });
+    }
+
+    get desc () { return `${this.uuid}@${this.branch}`; }
+}
 
 export class AutoPull {
     constructor (opts) {
@@ -49,14 +55,14 @@ export class AutoPull {
         const updates = spec => rx.defer(() => rx.of(Math.random()*5000)).pipe(
             rx.mergeMap(jitter => rx.timer(jitter, spec.interval)),
             rx.tap({
-                next:       () => this.log(`UPDATE ${spec.uuid}@${spec.branch}`),
-                subscribe:  () => this.log(`START ${spec.uuid}@${spec.branch}`),
-                finalize:   () => this.log(`STOP ${spec.uuid}@${spec.branch}`),
+                next:       () => this.log(`UPDATE ${spec.desc}`),
+                subscribe:  () => this.log(`START ${spec.desc}`),
+                finalize:   () => this.log(`STOP ${spec.desc}`),
             }),
             /* exhaustMap will avoid running another update if the
              * previous is still running */
             rx.exhaustMap(() => this.update(spec)
-                .catch(e => this.log("UPDATE ERROR: %s", e))),
+                .catch(e => this.log("UPDATE ERROR %s: %s", spec.desc, e))),
         );
 
         /* status.configs is a seq of imm.Map */

--- a/lib/auto-pull.js
+++ b/lib/auto-pull.js
@@ -87,7 +87,14 @@ export class AutoPull {
                 : Promise.reject(e))
         const before = await get_ref(spec.branch);
 
-        await git.addRemote({ fs, gitdir, remote, url: spec.url });
+        /* There should be noone else trying to create remotes on this
+         * repo. However, this update() is not atomic, and if we are
+         * killed partway through the remote will not be removed. So,
+         * although it's slightly risky, just force creation of the
+         * remote. (The alternatives would be to gensym a remote name,
+         * which would then lead to leakage of remotes, or to implement
+         * some sort of lock on the repo.) */
+        await git.addRemote({ fs, gitdir, remote, url: spec.url, force: true });
         const mirror = await git.fetch({
             fs, gitdir, http, remote,
             singleBranch:   true,

--- a/lib/auto-pull.js
+++ b/lib/auto-pull.js
@@ -116,6 +116,7 @@ export class AutoPull {
         }
 
         await git.deleteRemote({ fs, gitdir, remote });
+        this.status.update(spec.uuid);
     }
 
     run () {


### PR DESCRIPTION
* Overwrite old git remotes left behind when the process exits halfway through an update.
* Make sure we notify over MQTT on auto-pull.